### PR TITLE
PNP-12332 Fixed model generation

### DIFF
--- a/Extraction/Extractor/JmsExtractor.php
+++ b/Extraction/Extractor/JmsExtractor.php
@@ -118,6 +118,8 @@ class JmsExtractor implements ExtractorInterface
                 $propertySchema->readOnly = true;
             }
 
+            $propertySchema->serializerGroups = $item->groups;
+
             $name = $this->namingStrategy->translateName($item);
             $schema->properties[$name] = $propertySchema;
             $propertySchema->description = $this->getDescription($item);

--- a/Extraction/Extractor/TypeSchemaExtractor.php
+++ b/Extraction/Extractor/TypeSchemaExtractor.php
@@ -52,6 +52,8 @@ class TypeSchemaExtractor implements ExtractorInterface
      * @param string $source
      * @param SupportedTarget $target
      * @param ExtractionContextInterface $extractionContext
+     *
+     * @throws ExtractionImpossibleException
      */
     public function extract($source, $target, ExtractionContextInterface $extractionContext)
     {
@@ -130,7 +132,7 @@ class TypeSchemaExtractor implements ExtractorInterface
             $this->definitionHashes[$modelName][] = $hash;
         }
 
-        return array_search($hash, $this->definitionHashes);
+        return array_search($hash, $this->definitionHashes[$modelName]);
     }
 
     private function getPrimitiveType($type)

--- a/Extraction/Extractor/TypeSchemaExtractor.php
+++ b/Extraction/Extractor/TypeSchemaExtractor.php
@@ -107,7 +107,12 @@ class TypeSchemaExtractor implements ExtractorInterface
             // If definition for Entity is already registered and we are generating output model, merge serializer groups
             if ($rootSchema->hasDefinition($definitionName) && $direction === 'out') {
                 $lastContext = $rootSchema->definitions[$definitionName]->serializerGroups;
-                $extractionContext->setParameter('out-model-context', array_merge_recursive($lastContext, $context));
+                if (isset($context['serializer-groups'])) {
+                    $context['serializer-groups'] = array_unique(array_merge($lastContext, $context['serializer-groups']));
+                } else {
+                    $context['serializer-groups'] = $lastContext;
+                }
+
             }
 
             // If definition has not been added and processed yet OR if we are generating output model,
@@ -115,7 +120,9 @@ class TypeSchemaExtractor implements ExtractorInterface
             if(!$rootSchema->hasDefinition($definitionName) || $direction === 'out') {
                 $rootSchema->addDefinition($definitionName, $refSchema = new Schema());
                 $refSchema->type = "object";
-                $refSchema->serializerGroups = $context;
+                if (isset($context['serializer-groups'])) {
+                    $refSchema->serializerGroups = $context['serializer-groups'];
+                }
                 $extractionContext->getSwagger()->extract(
                     $reflectionClass,
                     $refSchema ,

--- a/Schema/Schema.php
+++ b/Schema/Schema.php
@@ -267,6 +267,16 @@ class Schema implements \ArrayAccess
     public $ref;
 
     /**
+     * Serializer groups extracted from annotations
+     *
+     * @var array
+     *
+     * @JMS\Type("array<string>")
+     * @JMS\Exclude(if="object.ref !== null")
+     */
+    public $serializerGroups;
+
+    /**
      * @JMS\PreSerialize()
      */
     public function preSerialize()


### PR DESCRIPTION
Added serializerGroups property in Schema class to save properties' serializer groups (for comments in output model). Also using it to append entity's serializer groups over iterations.

Commented-out functionality, which created different definitions per each serializer groups combination and as a result - multiple models per entity.